### PR TITLE
Avoid exception if grids table doesn't exist

### DIFF
--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -221,10 +221,10 @@ def mbtiles_to_disk(mbtiles_file, directory_path, **kwargs):
         t = tiles.fetchone()
 
     # grids
-    count = con.execute('select count(zoom_level) from grids;').fetchone()[0]
     done = 0
     msg =''
     try:
+        count = con.execute('select count(zoom_level) from grids;').fetchone()[0]
         grids = con.execute('select zoom_level, tile_column, tile_row, grid from grids;')
         g = grids.fetchone()
     except sqlite3.OperationalError:


### PR DESCRIPTION
Otherwise we get an exception like the following one :

Traceback (most recent call last):
  File "mb-util", line 50, in <module>
    mbtiles_to_disk(mbtiles_file, directory_path, **options.**dict**)
  File "/home/even/gdal/svn/trunk/gdal/mbutil/mbutil/util.py", line 224, in mbtiles_to_disk
    count = con.execute('select count(zoom_level) from grids;').fetchone()[0]
sqlite3.OperationalError: no such table: grids
