### PR TITLE
Import broken, XYZ never implemented

### DIFF
--- a/mb-util
+++ b/mb-util
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     $ mb-util tiles world.mbtiles # mbtiles file must not already exist""")
     
     parser.add_option('--scheme', dest='scheme',
-        help='''Tiling scheme for exporting tiles. Default is "xyz" (z/x/y),
+        help='''Tiling scheme of the tiles. Default is "xyz" (z/x/y),
             other option is "tms" which is also z/x/y
             but uses a flipped y coordinate''',
         type='string',


### PR DESCRIPTION
As reported at http://support.mapbox.com/discussions/general-questions/2682-mb-util-exportimport-no-such-file-error
the import of exported mbtiles does not run.

It is possible to import only if there is no version/name prefix such as "1.0.0/layer-name" and only TMS tiles.
Right now default for export is "XYZ".

Solution:
- Implemented flip_y() call for XYZ scheme (which is now default) during importing
- The "version/name" subdirectory prefix has been removed during the export. I expect it is there only for dummy WMTS implementations (where it is not required by the standard anyway). It does not hold any information. Directory with metadata.json can anyway only contain one tileset.

Now import and export of the same .mbtiles runs (beside grids were not implemented before either) for both TMS and XYZ scheme.
