### PR TITLE
Add do_compression option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Python installation (requires easy_install)
     $ mb-util -h
     Usage: mb-util [options] input output
 
-        Examples:
-        Export an mbtiles file to a directory of files:
+    Examples:
 
+        Export an mbtiles file to a directory of files:
         $ mb-util world.mbtiles tiles # tiles must not already exist
 
         Import a directory of tiles into an mbtiles file:
@@ -48,6 +48,13 @@ Python installation (requires easy_install)
                        other options are "tms" which is also z/x/y
                        but uses a flipped y coordinate, and "wms" which replicates
                        the MapServer WMS TileCache directory structure "z/000/000/x/000/000/y.png"''',
+      --image_format=FORMAT
+                            The format of the image tiles, either png or jpg
+      --grid_callback=CALLBACK
+                            Option to control JSONP callback for UTFGrid tiles. If
+                            grids are not used as JSONP,             you can
+                            remove callbacks specifying --grid_callback=""
+      --do_compression      Do mbtiles compression
 
     Export an `mbtiles` file to files on the filesystem:
 

--- a/mb-util
+++ b/mb-util
@@ -44,6 +44,11 @@ if __name__ == '__main__':
             you can remove callbacks specifying --grid_callback="" ''',
         default='grid')
 
+    parser.add_option('--do_compression', dest='compression',
+        help='''Do mbtiles compression''',
+        action="store_true",
+        default=False)
+
     (options, args) = parser.parse_args()
 
     # Transfer operations

--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -48,7 +48,7 @@ def optimize_connection(cur):
     cur.execute("""PRAGMA locking_mode=EXCLUSIVE""")
     cur.execute("""PRAGMA journal_mode=DELETE""")
 
-def compression_prepare(cur, con):
+def compression_prepare(cur):
     logger.debug('Prepare database compression.')
     cur.execute("""
       CREATE TABLE if not exists images (
@@ -221,7 +221,7 @@ def disk_to_mbtiles(directory_path, mbtiles_file, **kwargs):
     logger.debug('tiles (and grids) inserted.')
 
     if kwargs.get('compression', False):
-        compression_prepare(cur, con)
+        compression_prepare(cur)
         compression_do(cur, con, 256)
         compression_finalize(cur)
 


### PR DESCRIPTION
When I try to use that function, number of tiles was reduced by half but size of database increases!

``` bash
./mb-util --scheme=tms ~/coding/tiles_page/gits/ gits.mbtiles
./mb-util --do_compression --scheme=tms ~/coding/tiles_page/gits/ gits_compressed.mbtiles

sqlite3 gits_compressed_integer.mbtiles 'select count(*) from images;'
100818

sqlite3 gits.mbtiles 'select count(*) from tiles;'
200747

ls -sh | grep gits
264M gits.mbtiles
270M gits_compressed.mbtiles
```

Then I replaced type of field tile_id from string (uuid) to integer (aka regular foreign key) and I got following results:

``` bash
ls -sh | grep gits
264M gits.mbtiles
270M gits_compressed.mbtiles
256M gits_compressed_integer.mbtiles
```

Is there any reason to use uuid instead of simple integer?

https://github.com/mapbox/mbutil/issues/38, https://github.com/mapbox/mbutil/issues/39, https://github.com/mapbox/mbutil/issues/40
