### PR TITLE
Patch lean grids

### DIFF
--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -279,9 +279,14 @@ def mbtiles_to_disk(mbtiles_file, directory_path, **kwargs):
 
 def check_for_grids(con):
     try:
-        count = con.execute('select count(zoom_level) from grids;').fetchone()[0]
-        return True
+        count = con.execute('select count(zoom_level) from grid_data WHERE key_json NOT NULL;').fetchone()[0]
+        logger.debug('count: %s' % count)
+        if count > 0:
+            return True
+        else:
+            return False
     except sqlite3.OperationalError:
+        raise
         return False # no grids table
 
 

--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -313,6 +313,7 @@ def write_grid(base_path, con, kwargs, z, x, y):
         grid_data = grid_data_cursor.fetchone()
         data = {}
         while grid_data:
+            logger.debug(g)
             data[grid_data[0]] = json.loads(grid_data[1])
             grid_data = grid_data_cursor.fetchone()
         grid_json['data'] = data

--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -285,22 +285,22 @@ def check_for_grids(con):
         return False # no grids table
 
 
-def write_grid(base_path, con, kwargs, zoom_level, x, y):
+def write_grid(base_path, con, kwargs, z, x, y):
     msg = ''
     try:
         grid_cursor = con.execute('''select grid from grids WHERE
-            zoom_level = %(zoom_level)d and
-            tile_column = %(tile_column)d and
+            zoom_level = %(z)d and
+            tile_column = %(x)d and
             tile_row = %(y)d;''' % locals())
         grid_data_cursor = con.execute('''select key_name, key_json FROM
             grid_data WHERE
-            zoom_level = %(zoom_level)d and
-            tile_column = %(tile_column)d and
+            zoom_level = %(z)d and
+            tile_column = %(x)d and
             tile_row = %(y)d;''' % locals())
 
         if kwargs.get('scheme') == 'xyz':
-            y = flip_y(zoom_level, y)
-        grid_dir = os.path.join(base_path, str(zoom_level), str(x))
+            y = flip_y(z, y)
+        grid_dir = os.path.join(base_path, str(z), str(x))
         if not os.path.isdir(grid_dir):
             os.makedirs(grid_dir)
         grid = os.path.join(grid_dir, '%s.grid.json' % (y))


### PR DESCRIPTION
Here's a shot at basing what grids get exported dependent on the tiles routine. Rather than doing one query for all grids, which results in lots of empty grids in tilesets where there are a lot of areas without tiles, this version runs a separate write_grid function each time a tile is created. This creates many more queries, but I didn't see much if any decrease in exporting performance at the 50k-100k tile range. And any slowdown is more than made up for by not having to export and upload empty tiles.
