### PR TITLE
Fix strange spacing in help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,26 +35,28 @@ Python installation (requires easy_install)
     Usage: mb-util [options] input output
 
         Examples:
-        Export an mbtiles file to a directory of files:
 
+        Export an mbtiles file to a directory of files:
         $ mb-util world.mbtiles tiles # tiles must not already exist
 
         Import a directory of tiles into an mbtiles file:
         $ mb-util tiles world.mbtiles # mbtiles file must not already exist
 
     Options:
-      -h, --help       show this help message and exit
-      --scheme=SCHEME  Tiling scheme of the tiles. Default is "xyz" (z/x/y),
-                       other options are "tms" which is also z/x/y
-                       but uses a flipped y coordinate, and "wms" which replicates
-                       the MapServer WMS TileCache directory structure "z/000/000/x/000/000/y.png"'''
+      -h, --help            show this help message and exit
+      --scheme=SCHEME       Tiling scheme of the tiles. Default is "xyz" (z/x/y),
+                            other options are "tms" which is also z/x/y but uses a
+                            flipped y coordinate, and "wms" which replicates the
+                            MapServer WMS TileCache directory structure
+                            "z/000/000/x/000/000/y.png"
       --image_format=FORMAT
-                       The format of the image tiles, either png, jpg, webp
-                       or pbf
+                            The format of the image tiles, either png, jpg, webp
+                            or pbf
       --grid_callback=CALLBACK
-                       Option to control JSONP callback for UTFGrid tiles. If
-                       grids are not used as JSONP, you can remove callbacks 
-                       specifying --grid_callback=""
+                            Option to control JSONP callback for UTFGrid tiles. If
+                            grids are not used as JSONP, you can remove callbacks
+                            specifying --grid_callback=""
+
 
     Export an `mbtiles` file to files on the filesystem:
 

--- a/mb-util
+++ b/mb-util
@@ -26,10 +26,10 @@ if __name__ == '__main__':
     $ mb-util tiles world.mbtiles # mbtiles file must not already exist""")
     
     parser.add_option('--scheme', dest='scheme',
-        help='''Tiling scheme of the tiles. Default is "xyz" (z/x/y),
-            other options are "tms" which is also z/x/y
-            but uses a flipped y coordinate, and "wms" which replicates
-            the MapServer WMS TileCache directory structure "z/000/000/x/000/000/y.png"''',
+        help='''Tiling scheme of the tiles. Default is "xyz" (z/x/y), other options '''
+        + '''are "tms" which is also z/x/y but uses a flipped y coordinate, and "wms" '''
+        + '''which replicates the MapServer WMS TileCache directory structure '''
+        + '''"z/000/000/x/000/000/y.png"''',
         type='choice',
         choices=['wms', 'tms', 'xyz'],
         default='xyz')
@@ -40,8 +40,8 @@ if __name__ == '__main__':
         default='png')
 
     parser.add_option('--grid_callback', dest='callback',
-        help='''Option to control JSONP callback for UTFGrid tiles. If grids are not used as JSONP,
-            you can remove callbacks specifying --grid_callback="" ''',
+        help='''Option to control JSONP callback for UTFGrid tiles. If grids are not '''
+        + '''used as JSONP, you can remove callbacks specifying --grid_callback="" ''',
         default='grid')
 
     (options, args) = parser.parse_args()


### PR DESCRIPTION
Before this change, I see:
  --scheme=SCHEME       Tiling scheme of the tiles. Default is "xyz" (z/x/y),
                        other options are "tms" which is also z/x/y
                        but uses a flipped y coordinate, and "wms" which
                        replicates             the MapServer WMS TileCache
                        directory structure "z/000/000/x/000/000/y.png"
  --image_format=FORMAT
                        The format of the image tiles, either png, jpg, webp
                        or pbf
  --grid_callback=CALLBACK
                        Option to control JSONP callback for UTFGrid tiles. If
                        grids are not used as JSONP,             you can
                        remove callbacks specifying --grid_callback=""

Note the big gaps in the --scheme and --grid_callback text. Looks like the quotes
are confusing OptionParser. So work around that.