### PR TITLE
Add 'dump's parameter — e.g.,  $ mb-util world.mbtiles dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,10 @@ MBUtil imports and exports metadata as JSON, in the root of the tile directory, 
 This project uses [nosetests](http://readthedocs.org/docs/nose/en/latest/) for testing. Install nosetests:
 
     pip install nose
+or
 
+    easy_install nose
+    
 Then run:
 
     nosetests

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Python installation (requires easy_install)
     Usage: mb-util [options] input output
 
         Examples:
+        Export an mbtiles file to a directory of files:
+        $ mb-util world.mbtiles dumps # when the 2nd argument is "dumps", then dumps the metatdata.json
 
         Export an mbtiles file to a directory of files:
         $ mb-util world.mbtiles tiles # tiles must not already exist

--- a/mb-util
+++ b/mb-util
@@ -4,6 +4,7 @@
 # Supports importing, exporting, and more
 # 
 # (c) Development Seed 2012
+# (c) 2016 ePi Rational, Inc.
 # Licensed under BSD
 
 import logging, os, sys
@@ -18,7 +19,10 @@ if __name__ == '__main__':
     parser = OptionParser(usage="""usage: %prog [options] input output
     
     Examples:
-    
+
+    Export an mbtiles file to a directory of files:
+    $ mb-util world.mbtiles dumps # when the 2nd argument is "dumps", then dumps the metatdata.json
+
     Export an mbtiles file to a directory of files:
     $ mb-util world.mbtiles tiles # tiles must not already exist
     
@@ -56,10 +60,14 @@ if __name__ == '__main__':
         sys.exit(1)
     
     # to disk
+    if os.path.isfile(args[0]) and args[1]=="dumps":
+        mbtiles_file, dumps = args
+        mbtiles_metadata_to_disk(mbtiles_file, **options.__dict__)
+        sys.exit(1)
+
     if os.path.isfile(args[0]) and not os.path.exists(args[1]):
         mbtiles_file, directory_path = args
         mbtiles_to_disk(mbtiles_file, directory_path, **options.__dict__)
-        mbtiles_metadata_to_disk(mbtiles_file, **options.__dict__)
 
     if os.path.isdir(args[0]) and os.path.isfile(args[1]):
         sys.stderr.write('Importing tiles into already-existing MBTiles is not yet supported\n')

--- a/mb-util
+++ b/mb-util
@@ -9,7 +9,7 @@
 import logging, os, sys
 from optparse import OptionParser
 
-from mbutil import mbtiles_to_disk, disk_to_mbtiles
+from mbutil import mbtiles_to_disk, disk_to_mbtiles, mbtiles_metadata_to_disk
 
 if __name__ == '__main__':
 
@@ -59,7 +59,8 @@ if __name__ == '__main__':
     if os.path.isfile(args[0]) and not os.path.exists(args[1]):
         mbtiles_file, directory_path = args
         mbtiles_to_disk(mbtiles_file, directory_path, **options.__dict__)
-    
+        mbtiles_metadata_to_disk(mbtiles_file, **options.__dict__)
+
     if os.path.isdir(args[0]) and os.path.isfile(args[1]):
         sys.stderr.write('Importing tiles into already-existing MBTiles is not yet supported\n')
         sys.exit(1)

--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -217,6 +217,12 @@ def disk_to_mbtiles(directory_path, mbtiles_file, **kwargs):
     logger.debug('tiles (and grids) inserted.')
     optimize_database(con)
 
+def mbtiles_metadata_to_disk(mbtiles_file, **kwargs):
+    logger.debug("Exporting MBTiles metatdata from %s" % (mbtiles_file))
+    con = mbtiles_connect(mbtiles_file)
+    metadata = dict(con.execute('select name, value from metadata;').fetchall())
+    logger.debug(json.dumps(metadata, indent=2))
+
 def mbtiles_to_disk(mbtiles_file, directory_path, **kwargs):
     logger.debug("Exporting MBTiles to disk")
     logger.debug("%s --> %s" % (mbtiles_file, directory_path))


### PR DESCRIPTION
mb-util is very useful, and I found myself extracting tiles to disk just to peek at the metadata.json.

This pull request adds a new parameter that uses json.dumps to dump the contents of the metadata to stdout.

usage
```
mb-util world.mbtiles dumps
```