### PR TITLE
Enabled support for ArcGIS Cache Format.

### DIFF
--- a/mb-util
+++ b/mb-util
@@ -35,7 +35,7 @@ if __name__ == '__main__':
         + '''which replicates the MapServer WMS TileCache directory structure '''
         + '''"z/000/000/x/000/000/y.png"''',
         type='choice',
-        choices=['wms', 'tms', 'xyz', 'gwc'],
+        choices=['wms', 'tms', 'xyz', 'gwc','ags'],
         default='xyz')
         
     parser.add_option('--image_format', dest='format',

--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -178,7 +178,7 @@ def disk_to_mbtiles(directory_path, mbtiles_file, **kwargs):
         for rowDir in getDirs(os.path.join(directory_path, zoomDir)):
             if kwargs.get("scheme") == 'ags':
                 y = flip_y(z, int(rowDir.replace("R", ""), 16))
-            if kwargs.get("scheme") == 'gwc':
+            elif kwargs.get("scheme") == 'gwc':
                 pass
             else:
                 x = int(rowDir)


### PR DESCRIPTION
The underlying code for ArcGIS cache was done several years back however the CLI argument checks blocked users from being able to use it this reactivates it.

I've test both import and export with the format.