### PR TITLE
release preliminary python 3.5 support, v0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - 2.6
   - 2.7
+  - 3.5
 install:
   - pip install nose
 script:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+### v0.3.0
+* Preliminary Python 3 support
+
+### v0.2.0
+* ? See closed PRs
+
 ### v0.1.0
 
 * Switch tests to nosetest

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='mbutil',
-    version='0.2.0',
+    version='0.3.0',
     author='Tom MacWright',
     author_email='tom@macwright.org',
     packages=['mbutil'],


### PR DESCRIPTION
~~Python 3.6 support is blocked by #83~~

But @JamesMilnerUK's fix in #81 gets the tests passing on python 3.5. Let's get this released to pypi. 