### PR TITLE
only get image_format once and default to 'png'

### DIFF
--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -177,12 +177,10 @@ def disk_to_mbtiles(directory_path, mbtiles_file, **kwargs):
     cur = con.cursor()
     optimize_connection(cur)
     mbtiles_setup(cur)
-    #~ image_format = 'png'
     image_format = kwargs.get('format', 'png')
 
     try:
         metadata = json.load(open(os.path.join(directory_path, 'metadata.json'), 'r'))
-        image_format = kwargs.get('format')
         for name, value in metadata.items():
             cur.execute('insert into metadata (name, value) values (?, ?)',
                 (name, value))


### PR DESCRIPTION
closes #92 to ensure image_format defaults to png.

Though I still don't completely understand what mbutil should do here.

Image format can appear in the metadata.json (when converting tiles to mbtiles) and in the metadata table (when converting mbtiles to tiles), so I'm not sure what the image_format option should do, should it override the existing metadata? I don't know.