### PR TITLE
Ignore unexpected files

### DIFF
--- a/mbutil/util.py
+++ b/mbutil/util.py
@@ -222,6 +222,8 @@ def disk_to_mbtiles(directory_path, mbtiles_file, **kwargs):
                     logger.warning("Your OS is MacOS,and the .DS_Store file will be ignored.")
                 else:
                     file_name, ext = current_file.split('.',1)
+                    if (ext != image_format and ext != 'grid.json'):
+                        continue
                     f = open(os.path.join(directory_path, zoom_dir, row_dir, current_file), 'rb')
                     file_content = f.read()
                     f.close()


### PR DESCRIPTION
Fix for ignoring unexpected files (non files with defined extension or grid.json) like Thumbs.db (in Windows stores) and other