### PR TITLE
README: Change unsupported cloning scheme from git to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ that works for you - tiles on disk are notoriously difficult to manage.
 
 Git checkout (requires git)
 
-    git clone git://github.com/mapbox/mbutil.git
+    git clone https://github.com/mapbox/mbutil.git
     cd mbutil
     # get usage
     ./mb-util -h


### PR DESCRIPTION
It seems that by default, [The unauthenticated git protocol on port 9418 is no longer supported.](https://stackoverflow.com/questions/70663523/the-unauthenticated-git-protocol-on-port-9418-is-no-longer-supported)

![Screenshot from 2022-04-04 09-29-09](https://user-images.githubusercontent.com/5436722/161485966-6766c1a8-8cf9-4913-9d35-04edc71a259b.png)

So, you can easily change this to https and save some troubleshooting time to newcomers..
![Screenshot from 2022-04-04 09-29-25](https://user-images.githubusercontent.com/5436722/161485980-f8fdaac7-e773-4b35-9b4c-228a218a011c.png)
